### PR TITLE
v1.1: support local dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN /app/compile.sh
 FROM ghcr.io/broadsheet-technology/wordpress:0.5
 
 LABEL maintainer="Will Haynes <will@broadsheet.technology>"
-LABEL version="1.0"
+LABEL version="1.1"
 LABEL description="Support the Herald!"
 
 COPY --from=compiled-theme /app/dist/wp-content/themes/. /srv/themes/.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,15 @@ COPY . .
 
 RUN /app/compile.sh
 
-FROM ghcr.io/broadsheet-technology/wordpress:0.4
+FROM ghcr.io/broadsheet-technology/wordpress:0.5
 
 LABEL maintainer="Will Haynes <will@broadsheet.technology>"
 LABEL version="1.0"
 LABEL description="Support the Herald!"
 
-COPY --from=compiled-theme /app/dist/wp-content/themes/. /var/www/html/wp-content/themes/.
-RUN chown -R www-data:www-data /var/www/html/wp-content/themes
-RUN chmod -R 755 /var/www/html/wp-content/themes
+COPY --from=compiled-theme /app/dist/wp-content/themes/. /srv/themes/.
+RUN chown -R www-data:www-data /srv/themes
+RUN chmod -R 755 /srv/themes
 
 COPY --from=compiled-theme /app/dist/stencil-stats.json /srv/stencil-stats.json
 RUN chown -R www-data:www-data /srv/stencil-stats.json

--- a/config/nginx/support.badgerherald.org.conf
+++ b/config/nginx/support.badgerherald.org.conf
@@ -8,7 +8,6 @@ http {
   client_max_body_size 20m;
 
   access_log /dev/stdout;
-  proxy_cache_path /etc/nginx/cache levels=1:2 keys_zone=app:10m max_size=10g inactive=60m use_temp_path=off;
 
   server {
     listen 80;
@@ -66,13 +65,6 @@ http {
     text/x-cross-domain-policy;
 
     location /wp-content {
-      open_file_cache          max=1000 inactive=60s;
-      open_file_cache_valid    60s;
-      open_file_cache_min_uses 2;
-      open_file_cache_errors   on;
-
-      gzip_static on;
-
       alias /var/www/html/wp-content;
     }
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,9 +1,14 @@
 services:
+  nginx:
+    volumes:
+      - ./bin/wp-content/themes:/var/www/html/wp-content/themes
+  
   wordpress:
     depends_on:
       - mariadb
     volumes:
-      - ./bin/wp-content/themes/support.badgerherald.org:/var/www/html/wp-content/themes/support.badgerherald.org
+      - ./bin/stencil-stats.json:/srv/stencil-stats.json
+      - ./bin/wp-content/themes:/var/www/html/wp-content/themes
 
   mariadb:
     container_name: ${COMPOSE_PROJECT_NAME}-mariadb


### PR DESCRIPTION
Bump ghcr.io/broadsheet-technology/wordpress to 0.5 and turn off server caching for files that change in development